### PR TITLE
Provide context for context menu item

### DIFF
--- a/menus/show-first-line-on-tab.cson
+++ b/menus/show-first-line-on-tab.cson
@@ -6,7 +6,7 @@
       'command': 'show-first-line-on-tab:saveuntitled'
     },
     {
-      'label': 'Toggle'
+      'label': 'Toggle show-first-line-on-tab'
       'command': 'show-first-line-on-tab:toggle'
     }
   ]


### PR DESCRIPTION
Hi,

I just noticed an item in my context menu labeled 'Toggle' - I had no idea what it was. I tried it anyway and a notification popped up identifying this package.

This change just labels the context menu item more clearly so users can tell what they are toggling.

To be honest I'd prefer if packages didn't add this type of thing to the context menu. Toggling a package is not a contextual action, it's a global one, so the right place for this is the command palette. I don't feel strongly about this as I don't often use the context menu in Atom.